### PR TITLE
b/239365191 Decode and introspect STS token

### DIFF
--- a/sources/Google.Solutions.WWAuth.Test/Adapter/TestStsAdapter.cs
+++ b/sources/Google.Solutions.WWAuth.Test/Adapter/TestStsAdapter.cs
@@ -97,7 +97,7 @@ namespace Google.Solutions.WWAuth.Test.Adapter
         //---------------------------------------------------------------------
 
         [Test]
-        public void WhenClientCredentialsInvalid_ThenIntrospectTokenThrowsException()
+        public async Task WhenClientCredentialsInvalid_ThenIntrospectTokenThrowsException()
         {
             var adapter = new StsAdapter(
                 "//iam.googleapis.com/projects/PROJECT_NUMBER/locations/LOCATION/workloadIdentityPools/WORKLOAD_POOL_ID/providers/PROVIDER_ID",
@@ -108,10 +108,18 @@ namespace Google.Solutions.WWAuth.Test.Adapter
                 },
                 new NullLogger());
 
-            ExceptionAssert.ThrowsAggregateException<TokenExchangeException>(
-                () => adapter.IntrospectTokenAsync(
+            try
+            { 
+                await adapter.IntrospectTokenAsync(
                     "notatoken",
-                    CancellationToken.None).Wait());
+                    CancellationToken.None)
+                    .ConfigureAwait(false);
+                Assert.Fail("Expected exception");
+            }
+            catch (TokenExchangeException e)
+            {
+                StringAssert.Contains("Request has invalid basic authentication credentials.", e.Message);
+            }
         }
     }
 }

--- a/sources/Google.Solutions.WWAuth.Test/View/TestVerifyConfigurationViewModel.cs
+++ b/sources/Google.Solutions.WWAuth.Test/View/TestVerifyConfigurationViewModel.cs
@@ -178,6 +178,78 @@ namespace Google.Solutions.WWAuth.Test.View
         }
 
         //---------------------------------------------------------------------
+        // PerformTestAsync - token introspection.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public async Task WhenTokenIntrospectionFails_ThenStatusIsUpdated()
+        {
+            var tokenAdapter = new Mock<ITokenAdapter>();
+            tokenAdapter.Setup(t => t.AcquireTokenAsync(
+                    It.IsAny<TokenAcquisitionOptions>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Mock<ISubjectToken>().Object);
+
+            var stsAdapter = new Mock<IStsAdapter>();
+            stsAdapter.Setup(s => s.ExchangeTokenAsync(
+                    It.IsAny<ISubjectToken>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new TokenResponse());
+            stsAdapter.Setup(s => s.IntrospectTokenAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new TokenAcquisitionException("test"));
+
+            var vm = new VerifyConfigurationViewModel(
+                tokenAdapter.Object,
+                stsAdapter.Object,
+                new Mock<IServiceAccountAdapter>().Object,
+                new MemoryLogger(LogLevel.All));
+
+            await vm.PerformTestAsync(
+                    CancellationToken.None)
+                .ConfigureAwait(true);
+
+            Assert.IsTrue(vm.IsShowExternalTokenDetailsLinkEnabled);
+            Assert.IsFalse(vm.IsShowStsTokenDetailsLinkEnabled);
+        }
+
+        [Test]
+        public async Task WhenTokenIntrospectionSucceeds_ThenStatusIsUpdated()
+        {
+            var tokenAdapter = new Mock<ITokenAdapter>();
+            tokenAdapter.Setup(t => t.AcquireTokenAsync(
+                    It.IsAny<TokenAcquisitionOptions>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Mock<ISubjectToken>().Object);
+
+            var stsAdapter = new Mock<IStsAdapter>();
+            stsAdapter.Setup(s => s.ExchangeTokenAsync(
+                    It.IsAny<ISubjectToken>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new TokenResponse());
+            stsAdapter.Setup(s => s.IntrospectTokenAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Mock<ISubjectToken>().Object);
+
+            var vm = new VerifyConfigurationViewModel(
+                tokenAdapter.Object,
+                stsAdapter.Object,
+                new Mock<IServiceAccountAdapter>().Object,
+                new MemoryLogger(LogLevel.All));
+
+            await vm.PerformTestAsync(
+                    CancellationToken.None)
+                .ConfigureAwait(true);
+
+            Assert.IsTrue(vm.IsShowExternalTokenDetailsLinkEnabled);
+            Assert.IsTrue(vm.IsShowStsTokenDetailsLinkEnabled);
+        }
+
+        //---------------------------------------------------------------------
         // PerformTestAsync - impersonation.
         //---------------------------------------------------------------------
 

--- a/sources/Google.Solutions.WWAuth/Adapters/AdapterFactory.cs
+++ b/sources/Google.Solutions.WWAuth/Adapters/AdapterFactory.cs
@@ -19,6 +19,7 @@
 // under the License.
 //
 
+using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging;
 using Google.Apis.Util;
 using Google.Solutions.WWAuth.Adapters.Adfs;
@@ -79,6 +80,32 @@ namespace Google.Solutions.WWAuth.Adapters
 
                 default:
                     throw new ArgumentException("Unknown protocol: " + options.Protocol);
+            }
+        }
+
+        public static ClientSecrets ClientSecrets
+        {
+            get
+            {
+                //
+                // Use credentials from environment variable, if available.
+                //
+                if (Environment.GetEnvironmentVariable("WWAUTH_CLIENT_SECRET")
+                    is var credentials &&
+                    !string.IsNullOrEmpty(credentials) &&
+                    credentials.Split(':') is var credentialParts &&
+                    credentialParts.Length == 2)
+                {
+                    return new ClientSecrets()
+                    {
+                        ClientId = credentialParts[0],
+                        ClientSecret = credentialParts[1]
+                    };
+                }
+                else
+                {
+                    return null;
+                }
             }
         }
     }

--- a/sources/Google.Solutions.WWAuth/Google.Solutions.WWAuth.csproj
+++ b/sources/Google.Solutions.WWAuth/Google.Solutions.WWAuth.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Util\EnumExtensions.cs" />
     <Compile Include="Util\ExceptionExtensions.cs" />
     <Compile Include="Util\LinqExtensions.cs" />
+    <Compile Include="Util\RequestExtensions.cs" />
     <Compile Include="Util\SkipCodeCoverageAttribute.cs" />
     <Compile Include="Util\UrlSafeBase64.cs" />
     <Compile Include="View\AboutDialog.cs">

--- a/sources/Google.Solutions.WWAuth/Util/RequestExtensions.cs
+++ b/sources/Google.Solutions.WWAuth/Util/RequestExtensions.cs
@@ -1,0 +1,52 @@
+﻿//
+// Copyright 2022 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Requests;
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Google.Solutions.WWAuth.Util
+{
+    internal static class RequestExtensions
+    {
+        public static TRequest WithCredentials<TRequest, TResponse>(
+            this TRequest request,
+            ClientSecrets credentials)
+            where TRequest: ClientServiceRequest<TResponse>
+        {
+            if (credentials != null)
+            {
+                request.ModifyRequest = (HttpRequestMessage message) =>
+                {
+                    message.Headers.Authorization = new AuthenticationHeaderValue(
+                        "Basic",
+                        Convert.ToBase64String(
+                            Encoding.UTF8.GetBytes($"{credentials.ClientId}:{credentials.ClientSecret}")));
+                };
+            }
+
+            return request;
+        }
+    }
+}

--- a/sources/Google.Solutions.WWAuth/View/VerifyConfigurationDialog.Designer.cs
+++ b/sources/Google.Solutions.WWAuth/View/VerifyConfigurationDialog.Designer.cs
@@ -66,6 +66,7 @@ namespace Google.Solutions.WWAuth.View
             this.showExternalTokenDetailsLink = new System.Windows.Forms.LinkLabel();
             this.logsButton = new System.Windows.Forms.Button();
             this.showServiceAccountTokenDetailsLink = new System.Windows.Forms.LinkLabel();
+            this.showStsTokenDetailsLink = new System.Windows.Forms.LinkLabel();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.acuireTokenPictureBox)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.exchangeTokenPictureBox)).BeginInit();
@@ -233,6 +234,16 @@ namespace Google.Solutions.WWAuth.View
             this.showServiceAccountTokenDetailsLink.TabStop = true;
             this.showServiceAccountTokenDetailsLink.Text = "Show details";
             // 
+            // showStslTokenDetailsLink
+            // 
+            this.showStsTokenDetailsLink.AutoSize = true;
+            this.showStsTokenDetailsLink.Location = new System.Drawing.Point(226, 125);
+            this.showStsTokenDetailsLink.Name = "showStslTokenDetailsLink";
+            this.showStsTokenDetailsLink.Size = new System.Drawing.Size(67, 13);
+            this.showStsTokenDetailsLink.TabIndex = 12;
+            this.showStsTokenDetailsLink.TabStop = true;
+            this.showStsTokenDetailsLink.Text = "Show details";
+            // 
             // VerifyConfigurationDialog
             // 
             this.AcceptButton = this.okButton;
@@ -240,6 +251,7 @@ namespace Google.Solutions.WWAuth.View
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.cancelButton;
             this.ClientSize = new System.Drawing.Size(484, 311);
+            this.Controls.Add(this.showStsTokenDetailsLink);
             this.Controls.Add(this.showServiceAccountTokenDetailsLink);
             this.Controls.Add(this.showExternalTokenDetailsLink);
             this.Controls.Add(this.resultPanel);
@@ -290,5 +302,6 @@ namespace Google.Solutions.WWAuth.View
         private System.Windows.Forms.LinkLabel showExternalTokenDetailsLink;
         private System.Windows.Forms.Button logsButton;
         private System.Windows.Forms.LinkLabel showServiceAccountTokenDetailsLink;
+        private System.Windows.Forms.LinkLabel showStsTokenDetailsLink;
     }
 }

--- a/sources/Google.Solutions.WWAuth/View/VerifyConfigurationDialog.cs
+++ b/sources/Google.Solutions.WWAuth/View/VerifyConfigurationDialog.cs
@@ -19,10 +19,12 @@
 // under the License.
 //
 
+using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging;
 using Google.Solutions.WWAuth.Adapters;
 using Google.Solutions.WWAuth.Data;
 using Google.Solutions.WWAuth.Util;
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -45,7 +47,10 @@ namespace Google.Solutions.WWAuth.View
                 AdapterFactory.CreateTokenAdapter(
                     configuration.Options,
                     logger),
-                new StsAdapter(configuration.PoolConfiguration.Audience, logger),
+                new StsAdapter(
+                    configuration.PoolConfiguration.Audience,
+                    AdapterFactory.ClientSecrets, 
+                    logger),
                 new ServiceAccountAdapter(configuration.ServiceAccountEmail, logger),
                 logger);
 
@@ -119,6 +124,11 @@ namespace Google.Solutions.WWAuth.View
                 viewModel,
                 m => m.IsShowExternalTokenDetailsLinkEnabled,
                 this.Container);
+            this.showStsTokenDetailsLink.BindReadonlyProperty(
+                c => c.Visible,
+                viewModel,
+                m => m.IsShowStsTokenDetailsLinkEnabled,
+                this.Container);
             this.showServiceAccountTokenDetailsLink.BindReadonlyProperty(
                 c => c.Visible,
                 viewModel,
@@ -149,6 +159,17 @@ namespace Google.Solutions.WWAuth.View
                     prop.Text = "External token";
                     prop.FormBorderStyle = FormBorderStyle.Sizable;
                     prop.AddSheet(new ViewTokenSheet(viewModel.ExternalToken));
+                    prop.ShowDialog(this);
+                }
+            };
+
+            this.showStsTokenDetailsLink.LinkClicked += (sender, args) =>
+            {
+                using (var prop = new PropertiesDialog())
+                {
+                    prop.Text = "STS token";
+                    prop.FormBorderStyle = FormBorderStyle.Sizable;
+                    prop.AddSheet(new ViewTokenSheet(viewModel.StsToken));
                     prop.ShowDialog(this);
                 }
             };

--- a/sources/Google.Solutions.WWAuth/View/VerifyConfigurationViewModel.cs
+++ b/sources/Google.Solutions.WWAuth/View/VerifyConfigurationViewModel.cs
@@ -49,10 +49,12 @@ namespace Google.Solutions.WWAuth.View
         private bool isLogsButtonEnabled = false;
 
         private bool isShowExternalTokenDetailsLinkEnabled = false;
+        private bool isShowStsTokenDetailsLinkEnabled = false;
         private bool isShowServiceAccountTokenDetailsLinkEnabled = false;
 
         public ISubjectToken ExternalToken { get; private set; }
         public ISubjectToken ServiceAccountToken { get; private set; }
+        public ISubjectToken StsToken { get; private set; }
 
         public string Logs => string.Join("\r\n", this.logger.LogEntries);
 
@@ -189,6 +191,16 @@ namespace Google.Solutions.WWAuth.View
             }
         }
 
+        public bool IsShowStsTokenDetailsLinkEnabled
+        {
+            get => this.isShowStsTokenDetailsLinkEnabled;
+            private set
+            {
+                this.isShowStsTokenDetailsLinkEnabled = value;
+                RaisePropertyChange();
+            }
+        }
+
         public bool IsShowServiceAccountTokenDetailsLinkEnabled
         {
             get => this.isShowServiceAccountTokenDetailsLinkEnabled;
@@ -267,10 +279,28 @@ namespace Google.Solutions.WWAuth.View
                     throw;
                 }
 
+                //
+                // (3) Try to introspect STS token.
+                //
+                try
+                {
+                    this.StsToken = await this.stsAdapter
+                        .IntrospectTokenAsync(
+                            stsToken.AccessToken,
+                            cancellationToken)
+                        .ConfigureAwait(true);
+
+                    this.IsShowStsTokenDetailsLinkEnabled = true;
+                }
+                catch
+                {
+                    this.IsShowStsTokenDetailsLinkEnabled = false;
+                }
+
                 if (this.serviceAccountAdapter.IsEnabled)
                 {
                     //
-                    // (3) Impersonate.
+                    // (4) Impersonate.
                     //
                     try
                     {


### PR DESCRIPTION
Add link to decode and introspect STS token. This
feature is only available if the WWAUTH_CLIENT_SECRET
environment variable is set and contains valid
a client secret.