### PR TITLE
b/244505036 Prefill OIDC RP URL only after pool has been configured

### DIFF
--- a/sources/Google.Solutions.WWAuth.Test/View/TestAdfsConfigurationViewModel.cs
+++ b/sources/Google.Solutions.WWAuth.Test/View/TestAdfsConfigurationViewModel.cs
@@ -435,11 +435,36 @@ namespace Google.Solutions.WWAuth.Test.View
         //---------------------------------------------------------------------
 
         [Test]
-        public void WhenProtolIsOidc_ThenDefaultsAreApplied()
+        public void WhenProtolIsOidcAndPoolNotConfigured_ThenDefaultsAreApplied()
         {
             var file = CredentialConfigurationFile.NewWorkloadIdentityConfigurationFile();
             file.Configuration.Options.Protocol =
                 UnattendedCommandLineOptions.AuthenticationProtocol.AdfsOidc;
+
+            var vm = new AdfsConfigurationViewModel(
+                file,
+                new Mock<IShellAdapter>().Object,
+                new Mock<ICertificateStoreAdapter>().Object);
+            vm.ReapplyProtocolDefaults();
+
+            Assert.IsNull(vm.AcsUrl);
+            Assert.IsNull(vm.ClientId);
+            Assert.IsNull(vm.RelyingPartyId);
+
+            Assert.IsFalse(vm.IsDirty);
+        }
+
+        [Test]
+        public void WhenProtolIsOidcAndPoolConfigured_ThenDefaultsAreApplied()
+        {
+            var file = CredentialConfigurationFile.NewWorkloadIdentityConfigurationFile();
+            file.Configuration.Options.Protocol =
+                UnattendedCommandLineOptions.AuthenticationProtocol.AdfsOidc;
+
+            var poolConfig = (WorkloadIdentityPoolConfiguration)file.Configuration.PoolConfiguration;
+            poolConfig.ProjectNumber = 123;
+            poolConfig.ProviderName = "p-1";
+            poolConfig.PoolName = "p-1"; ;
 
             var vm = new AdfsConfigurationViewModel(
                 file,

--- a/sources/Google.Solutions.WWAuth/Data/IdentityPoolConfiguration.cs
+++ b/sources/Google.Solutions.WWAuth/Data/IdentityPoolConfiguration.cs
@@ -49,6 +49,22 @@ namespace Google.Solutions.WWAuth.Data
                     "Missing identity pool provider name.");
             }
         }
+
+        public bool IsValid
+        {
+            get
+            {
+                try
+                {
+                    Validate();
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/sources/Google.Solutions.WWAuth/View/AdfsConfigurationViewModel.cs
+++ b/sources/Google.Solutions.WWAuth/View/AdfsConfigurationViewModel.cs
@@ -251,7 +251,8 @@ namespace Google.Solutions.WWAuth.View
             {
                 case UnattendedCommandLineOptions.AuthenticationProtocol.AdfsOidc:
                     this.IsRelyingPartyIdTextBoxReadonly = false;
-                    if (string.IsNullOrEmpty(this.RelyingPartyId))
+                    if (string.IsNullOrEmpty(this.RelyingPartyId) &&
+                        this.File.Configuration.PoolConfiguration.IsValid)
                     {
                         this.RelyingPartyId = $"https:{this.File.Configuration.PoolConfiguration.Audience}";
                     }
@@ -270,10 +271,7 @@ namespace Google.Solutions.WWAuth.View
 
                 case UnattendedCommandLineOptions.AuthenticationProtocol.AdfsWsTrust:
                     this.IsRelyingPartyIdTextBoxReadonly = true;
-                    if (this.RelyingPartyId != this.DefaultRelyingPartyId)
-                    {
-                        this.RelyingPartyId = this.DefaultRelyingPartyId;
-                    }
+                    this.RelyingPartyId = this.DefaultRelyingPartyId;
 
                     this.IsClientIdTextBoxVisible = false;
                     if (!string.IsNullOrEmpty(this.ClientId))
@@ -293,10 +291,7 @@ namespace Google.Solutions.WWAuth.View
 
                 case UnattendedCommandLineOptions.AuthenticationProtocol.AdfsSamlPost:
                     this.IsRelyingPartyIdTextBoxReadonly = true;
-                    if (this.RelyingPartyId != this.DefaultRelyingPartyId)
-                    {
-                        this.RelyingPartyId = this.DefaultRelyingPartyId;
-                    }
+                    this.RelyingPartyId = this.DefaultRelyingPartyId;
 
                     this.IsClientIdTextBoxVisible = false;
                     if (!string.IsNullOrEmpty(this.ClientId))


### PR DESCRIPTION
* Don't prefill relying party field until pool has been fully configured
* Don't override user-supplied value